### PR TITLE
PRO-195: add CNAME file

### DIFF
--- a/src/static/CNAME
+++ b/src/static/CNAME
@@ -1,0 +1,1 @@
+docs.peridio.com


### PR DESCRIPTION
**Why**

- The CNAME file is necessary to route DNS correctly across docusaurus deploys.

**How**

- Add CNAME file to static dir.