### PR TITLE
PRO-225: disable dark mode switch

### DIFF
--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -45,6 +45,9 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      colorMode: {
+        disableSwitch: true,
+      },
       navbar: {
         logo: {
           alt: 'Peridio logo color black',


### PR DESCRIPTION
**Why**

Dark mode has some serious CSS/UI offenses that we simply cannot tolerate in this economy and as such we will hide the switch until a primetime-ready version of dark mode is implemented.