### PR TITLE
PRO-218: verify successful build of docs in CI

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,26 @@
+name: Test build
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test-build:
+    name: Test build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: yarn
+          cache-dependency-path: src/yarn.lock
+
+      - name: Install dependencies
+        run: yarn --cwd src install --frozen-lockfile
+      - name: Test build website
+        run: yarn --cwd src build


### PR DESCRIPTION
Why:

we want to make sure that the docs build correctly

How:

- add git actions workflow files that run `yarn build`