### PR TITLE
PRO-324: node types specs

### DIFF
--- a/src/docs/reference/node-types.md
+++ b/src/docs/reference/node-types.md
@@ -1,0 +1,9 @@
+---
+title: Node Types
+---
+
+<head>
+  <title>Ref | Node Types</title>
+</head>
+
+Node Types are the types of nodes that Peridio supports.

--- a/src/sidebars.js
+++ b/src/sidebars.js
@@ -22,6 +22,7 @@ const sidebars = {
     'reference/members',
     'reference/nerves',
     'reference/node-groups',
+    'reference/node-types',
     'reference/nodes'
   ],
   guides: [

--- a/src/static/openapi/openapi.yaml
+++ b/src/static/openapi/openapi.yaml
@@ -54,23 +54,24 @@ x-tagGroups:
       - "Distributions"
       - "Elements"
       - "Identity"
+      - "Node Types"
       - "Nodes"
 paths:
   /distributions:
     get:
       summary: list distributions
       tags:
-        - 'Distributions'
+        - "Distributions"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/array-of-distributions'
+                $ref: "#/components/schemas/array-of-distributions"
     post:
       summary: create distribution
       tags:
-        - 'Distributions'
+        - "Distributions"
       requestBody:
         required: true
         content:
@@ -78,37 +79,37 @@ paths:
             schema:
               properties:
                 element_version_id:
-                  $ref: '#/components/schemas/element-version-id'
+                  $ref: "#/components/schemas/element-version-id"
                 name:
-                  $ref: '#/components/schemas/name'
+                  $ref: "#/components/schemas/name"
               required:
                 - element_version_id
                 - name
       responses:
-        '200':
+        "200":
           description: Created.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/distribution'
+                $ref: "#/components/schemas/distribution"
   /distributions/{distribution_id}:
     get:
       summary: get distribution
       tags:
-        - 'Distributions'
+        - "Distributions"
       parameters:
         - name: distribution_id
           in: path
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/distribution'
+                $ref: "#/components/schemas/distribution"
     put:
       summary: update distribution
       tags:
-        - 'Distributions'
+        - "Distributions"
       parameters:
         - name: distribution_id
           in: path
@@ -119,28 +120,28 @@ paths:
             schema:
               properties:
                 name:
-                  $ref: '#/components/schemas/name'
+                  $ref: "#/components/schemas/name"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/distribution'
+                $ref: "#/components/schemas/distribution"
   /elements:
     get:
       summary: list elements
       tags:
-        - 'Elements'
+        - "Elements"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/array-of-elements'
+                $ref: "#/components/schemas/array-of-elements"
     post:
       summary: create element
       tags:
-        - 'Elements'
+        - "Elements"
       requestBody:
         required: true
         content:
@@ -148,34 +149,34 @@ paths:
             schema:
               properties:
                 name:
-                  $ref: '#/components/schemas/name'
+                  $ref: "#/components/schemas/name"
               required:
                 - name
       responses:
-        '200':
+        "200":
           description: Created.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/element'
+                $ref: "#/components/schemas/element"
   /elements/{element_id}:
     get:
       summary: get element
       tags:
-        - 'Elements'
+        - "Elements"
       parameters:
         - name: element_id
           in: path
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/element'
+                $ref: "#/components/schemas/element"
     put:
       summary: update element
       tags:
-        - 'Elements'
+        - "Elements"
       parameters:
         - name: element_id
           in: path
@@ -186,31 +187,31 @@ paths:
             schema:
               properties:
                 name:
-                  $ref: '#/components/schemas/name'
+                  $ref: "#/components/schemas/name"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/element'
+                $ref: "#/components/schemas/element"
   /elements/{element_id}/versions:
     get:
       summary: list versions
       tags:
-        - 'Elements'
+        - "Elements"
       parameters:
         - name: element_id
           in: path
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/array-of-element-versions'
+                $ref: "#/components/schemas/array-of-element-versions"
     post:
       summary: create version
       tags:
-        - 'Elements'
+        - "Elements"
       parameters:
         - name: element_id
           in: path
@@ -221,51 +222,51 @@ paths:
             schema:
               properties:
                 number:
-                  $ref: '#/components/schemas/element-version-number'
+                  $ref: "#/components/schemas/element-version-number"
               required:
                 - number
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/element-version'
+                $ref: "#/components/schemas/element-version"
   /elements/{element_id}/versions/{version_id}:
     get:
       summary: get version
       tags:
-        - 'Elements'
+        - "Elements"
       parameters:
         - name: element_id
           in: path
         - name: version_id
           in: path
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/element-version'
+                $ref: "#/components/schemas/element-version"
   /elements/{element_id}/versions/{version_id}/binaries:
     get:
       summary: list binaries
       tags:
-        - 'Elements'
+        - "Elements"
       parameters:
         - name: element_id
           in: path
         - name: version_id
           in: path
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/array-of-element-binaries'
+                $ref: "#/components/schemas/array-of-element-binaries"
     post:
       summary: create binary
       tags:
-        - 'Elements'
+        - "Elements"
       requestBody:
         required: true
         content:
@@ -275,17 +276,17 @@ paths:
               format: binary
               description: The submitted binary must be less than or equal to 1 GB.
       responses:
-        '200':
+        "200":
           description: Created.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/element-binary'
+                $ref: "#/components/schemas/element-binary"
   /elements/{element_id}/versions/{version_id}/binaries/{binary_id}:
     get:
       summary: get binary
       tags:
-        - 'Elements'
+        - "Elements"
       parameters:
         - name: element_id
           in: path
@@ -294,40 +295,40 @@ paths:
         - name: binary_id
           in: path
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/element-binary'
+                $ref: "#/components/schemas/element-binary"
   /identity:
     get:
       summary: Get
       description: |
         Gets information identifying the API Key used to authenticate the request, the Account it is a part of, and the Member it belongs to if applicable.
       tags:
-        - 'Identity'
+        - "Identity"
       responses:
-        '200':
+        "200":
           description: Ok.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/identity'
+                $ref: "#/components/schemas/identity"
   /nodes:
     get:
       summary: list nodes
       tags:
-        - 'Nodes'
+        - "Nodes"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/array-of-nodes'
+                $ref: "#/components/schemas/array-of-nodes"
     post:
       summary: create node
       tags:
-        - 'Nodes'
+        - "Nodes"
       requestBody:
         required: true
         content:
@@ -335,37 +336,37 @@ paths:
             schema:
               properties:
                 name:
-                  $ref: '#/components/schemas/name'
+                  $ref: "#/components/schemas/name"
                 node_group_id:
-                  $ref: '#/components/schemas/node-group-id'
+                  $ref: "#/components/schemas/node-group-id"
               required:
                 - node_group_id
                 - name
       responses:
-        '200':
+        "200":
           description: Created.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/node'
+                $ref: "#/components/schemas/node"
   /nodes/{node_id}:
     get:
       summary: get node
       tags:
-        - 'Nodes'
+        - "Nodes"
       parameters:
         - name: node_id
           in: path
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/node'
+                $ref: "#/components/schemas/node"
     put:
       summary: update node
       tags:
-        - 'Nodes'
+        - "Nodes"
       parameters:
         - name: node_id
           in: path
@@ -376,28 +377,28 @@ paths:
             schema:
               properties:
                 name:
-                  $ref: '#/components/schemas/name'
+                  $ref: "#/components/schemas/name"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/node'
+                $ref: "#/components/schemas/node"
   /node-groups:
     get:
       summary: list groups
       tags:
-        - 'Nodes'
+        - "Nodes"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/array-of-node-groups'
+                $ref: "#/components/schemas/array-of-node-groups"
     post:
       summary: create group
       tags:
-        - 'Nodes'
+        - "Nodes"
       requestBody:
         required: true
         content:
@@ -405,37 +406,37 @@ paths:
             schema:
               properties:
                 distribution_id:
-                  $ref: '#/components/schemas/distribution-id'
+                  $ref: "#/components/schemas/distribution-id"
                 name:
-                  $ref: '#/components/schemas/name'
+                  $ref: "#/components/schemas/name"
               required:
                 - distribution_id
                 - name
       responses:
-        '200':
+        "200":
           description: Created.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/node-group'
+                $ref: "#/components/schemas/node-group"
   /node-groups/{node_group_id}:
     get:
       summary: get group
       tags:
-        - 'Nodes'
+        - "Nodes"
       parameters:
         - name: node_group_id
           in: path
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/node-group'
+                $ref: "#/components/schemas/node-group"
     put:
       summary: update group
       tags:
-        - 'Nodes'
+        - "Nodes"
       parameters:
         - name: node_group_id
           in: path
@@ -446,13 +447,82 @@ paths:
             schema:
               properties:
                 name:
-                  $ref: '#/components/schemas/name'
+                  $ref: "#/components/schemas/name"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/node-group'
+                $ref: "#/components/schemas/node-group"
+  /node-types:
+    get:
+      summary: list node types
+      tags:
+        - "Node Types"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/array-of-node-types"
+    post:
+      summary: create node type
+      description: Name is unique
+      tags:
+        - "Node Types"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: "#/components/schemas/name"
+              required:
+                - name
+      responses:
+        "200":
+          description: Created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/node-type"
+  /node-types/{node_type_id}:
+    get:
+      summary: get node type
+      tags:
+        - "Node Types"
+      parameters:
+        - name: node_type_id
+          in: path
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/node-type"
+    put:
+      summary: update node type
+      description: Name is unique
+      tags:
+        - "Node Types"
+      parameters:
+        - name: node_type_id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: "#/components/schemas/name"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/node-type"
 components:
   schemas:
     account-id:
@@ -466,43 +536,49 @@ components:
       minItems: 0
       maxItems: 100
       items:
-        $ref: '#/components/schemas/distribution'
+        $ref: "#/components/schemas/distribution"
     array-of-element-ids:
       type: array
       minItems: 0
       maxItems: 100
       items:
-        $ref: '#/components/schemas/element-id'
+        $ref: "#/components/schemas/element-id"
     array-of-element-binaries:
       type: array
       minItems: 0
       maxItems: 100
       items:
-        $ref: '#/components/schemas/element-binary'
+        $ref: "#/components/schemas/element-binary"
     array-of-element-versions:
       type: array
       minItems: 0
       maxItems: 100
       items:
-        $ref: '#/components/schemas/element-version'
+        $ref: "#/components/schemas/element-version"
     array-of-elements:
       type: array
       minItems: 0
       maxItems: 100
       items:
-        $ref: '#/components/schemas/element'
+        $ref: "#/components/schemas/element"
     array-of-node-groups:
       type: array
       minItems: 0
       maxItems: 100
       items:
-        $ref: '#/components/schemas/node-group'
+        $ref: "#/components/schemas/node-group"
+    array-of-node-types:
+      type: array
+      minItems: 0
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/node-type"
     array-of-nodes:
       type: array
       minItems: 0
       maxItems: 100
       items:
-        $ref: '#/components/schemas/node'
+        $ref: "#/components/schemas/node"
     distribution:
       allOf:
         - type: object
@@ -511,11 +587,11 @@ components:
               type: string
               format: date-time
             id:
-              $ref: '#/components/schemas/distribution-id'
+              $ref: "#/components/schemas/distribution-id"
             name:
-              $ref: '#/components/schemas/name'
+              $ref: "#/components/schemas/name"
             element_version_id:
-              $ref: '#/components/schemas/element-version-id'
+              $ref: "#/components/schemas/element-version-id"
             updated_at:
               type: string
               format: date-time
@@ -530,9 +606,9 @@ components:
               type: string
               format: date-time
             id:
-              $ref: '#/components/schemas/element-id'
+              $ref: "#/components/schemas/element-id"
             name:
-              $ref: '#/components/schemas/name'
+              $ref: "#/components/schemas/name"
             updated_at:
               type: string
               format: date-time
@@ -546,7 +622,7 @@ components:
             hash:
               type: string
             id:
-              $ref: '#/components/schemas/element-binary-id'
+              $ref: "#/components/schemas/element-binary-id"
             size:
               type: integer
               format: bytes
@@ -554,7 +630,7 @@ components:
               type: string
               format: date-time
             version_id:
-              $ref: '#/components/schemas/element-version-id'
+              $ref: "#/components/schemas/element-version-id"
     element-binary-id:
       type: string
       format: uuid
@@ -569,11 +645,11 @@ components:
               type: string
               format: date-time
             element_id:
-              $ref: '#/components/schemas/element-id'
+              $ref: "#/components/schemas/element-id"
             id:
-              $ref: '#/components/schemas/element-version-id'
+              $ref: "#/components/schemas/element-version-id"
             number:
-              $ref: '#/components/schemas/element-version-number'
+              $ref: "#/components/schemas/element-version-number"
             updated_at:
               type: string
               format: date-time
@@ -584,13 +660,13 @@ components:
       type: object
       properties:
         api_key_id:
-          $ref: '#/components/schemas/api-key-id'
+          $ref: "#/components/schemas/api-key-id"
         account_id:
-          $ref: '#/components/schemas/account-id'
+          $ref: "#/components/schemas/account-id"
         member_id:
           anyOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/member-id'
+            - type: "null"
+            - $ref: "#/components/schemas/member-id"
     element-version-number:
       type: string
     member-id:
@@ -608,11 +684,11 @@ components:
               type: string
               format: date-time
             id:
-              $ref: '#/components/schemas/node-id'
+              $ref: "#/components/schemas/node-id"
             name:
-              $ref: '#/components/schemas/name'
+              $ref: "#/components/schemas/name"
             node_group_id:
-              $ref: '#/components/schemas/node-group-id'
+              $ref: "#/components/schemas/node-group-id"
             updated_at:
               type: string
               format: date-time
@@ -624,11 +700,25 @@ components:
               type: string
               format: date-time
             distribution_id:
-              $ref: '#/components/schemas/distribution-id'
+              $ref: "#/components/schemas/distribution-id"
             id:
-              $ref: '#/components/schemas/node-group-id'
+              $ref: "#/components/schemas/node-group-id"
             name:
-              $ref: '#/components/schemas/name'
+              $ref: "#/components/schemas/name"
+            updated_at:
+              type: string
+              format: date-time
+    node-type:
+      allOf:
+        - type: object
+          properties:
+            created_at:
+              type: string
+              format: date-time
+            id:
+              $ref: "#/components/schemas/node-type-id"
+            name:
+              $ref: "#/components/schemas/name"
             updated_at:
               type: string
               format: date-time


### PR DESCRIPTION
Why:

- We want to add specs for node types.

How:

- Add `Node Types` readme.
- Add "Node Types" to sidebar.
- Add `Node Types` to API spec.
- Run formatter on yaml.
