### PR TITLE
PRO-416: add base for cremini reference docs

### DIFF
--- a/src/cremini-sidebars.js
+++ b/src/cremini-sidebars.js
@@ -3,7 +3,16 @@
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
   reference: [
+    'reference/ca-certificates',
+    'reference/deployments',
+    'reference/device-certificates',
+    'reference/devices',
+    'reference/firmware',
+    'reference/just-in-time-registration',
+    'reference/keys',
     'reference/organizations',
+    'reference/products',
+    'reference/users',
   ],
 };
 

--- a/src/cremini/docs/reference/ca-certificates.md
+++ b/src/cremini/docs/reference/ca-certificates.md
@@ -1,0 +1,16 @@
+---
+title: CA Certificates
+---
+
+<head>
+  <title>Ref | CA Certificates</title>
+</head>
+
+A CA certificate is an X.509 certificate that signs [device certificates](device-certificates). The validity of said signature on the device's certificate is verified when a [user](users) creates a device certificate and as part of [just in time registration](just-in-time-registration).
+
+## Just in Time Registration
+
+CA certificates that are added to Peridio can optionally enable just in time registration. This will allow an unregistered [device](devices) to automatically become registered at the moment of its first connection to Peridio.
+
+As part of this configuration, you define a description, tags, and product to be applied to
+devices that register in this fashion.

--- a/src/cremini/docs/reference/deployments.md
+++ b/src/cremini/docs/reference/deployments.md
@@ -1,0 +1,21 @@
+---
+title: Deployments
+---
+
+<head>
+  <title>Ref | Deployments</title>
+</head>
+
+A deployment makes [firmware](firmware) available to [devices](devices) associated with the same [product](products) as the deployment and that satisfy the deployment's conditions. Deployments may be configured as active or not. Only active deployments may be considered when Peridio evaluates if an update is available for a device.
+
+## Conditions
+
+A deployment can restrict the devices it is applicable to by the tags associated with the device and by which version the device is currently on.
+
+### Tags
+
+When tags are specified as a condition for a deployment, a device  must have at least the tags specified by the deployment in order to meet the condition.
+
+### Version
+
+When a version is specified as a condition for a deployment, a device must meet meet this version requirement. For information regarding how version requirements are specified and evaluated, reference https://hexdocs.pm/elixir/Version.html#module-requirements.

--- a/src/cremini/docs/reference/device-certificates.md
+++ b/src/cremini/docs/reference/device-certificates.md
@@ -1,0 +1,9 @@
+---
+title: Device Certificates
+---
+
+<head>
+  <title>Ref | Device Certificates</title>
+</head>
+
+A [device](devices) certificate is an X.509 certificate that is signed by a [CA certificate](ca-certificates). Devices use their certificates to authenticate with the [Peridio Device API](../device-api) as well as during [just in time registration](just-in-time-registration).

--- a/src/cremini/docs/reference/devices.md
+++ b/src/cremini/docs/reference/devices.md
@@ -1,0 +1,29 @@
+---
+title: Devices
+---
+
+A device is the logical representation of a physical or virtual thing you wish to manage firmware for with Peridio.
+
+<head>
+  <title>Ref | Devices</title>
+</head>
+
+## Creation
+
+Devices can be created proactively or reactively. The former is sometimes convenient when just starting out or taking a one off action, but quickly becomes untenable. When you wish to optimize the process of onboarding devices it is typically best to take a reactive approach.
+
+### Proactive
+
+Proactive creation of devices means that you create a device before it ever attempts to connect to the Peridio Device API. You may do this via the Console or the Peridio Device API. When taking this approach you must subsequently create a certificate for it as well in order to facilitate its authentication with the Peridio Device API.
+
+### Reactive
+
+Reactive creation of devices means that you configure Peridio in such a way that groups of devices are able to connect to the Peridio Device API without you having taken any per device action, and in that moment they are reactively created by Peridio for you "just in time".
+
+For documentation regarding configuring Peridio in this fashion, reference [just in time registration](just-in-time-registration).
+
+## Tags
+
+Devices can be associated with tags to achieve logical groupings. These grouping may have external
+meaning to you, but they may also be used within Peridio to adjust the scope of devices to which a
+deployment is applicable as part of its configured [conditions](deployments#tags).

--- a/src/cremini/docs/reference/firmware.md
+++ b/src/cremini/docs/reference/firmware.md
@@ -1,0 +1,9 @@
+---
+title: Firmware
+---
+
+<head>
+  <title>Ref | Firmware</title>
+</head>
+
+Peridio leverages [FWUP](https://github.com/fwup-home/fwup) to create, sign, verify, and apply firmware.

--- a/src/cremini/docs/reference/just-in-time-registration.md
+++ b/src/cremini/docs/reference/just-in-time-registration.md
@@ -1,0 +1,15 @@
+---
+title: Just in Time Registration
+---
+
+<head>
+  <title>Ref | Just in Time Registration</title>
+</head>
+
+[Configuring just in time registration for a CA Certificate](ca-certificates#just-in-time-registration) enables a [device](devices) whose [certificate](device-certificates) is signed by that CA certificate to reactively register itself at the moment of its first connection to the [Peridio Device API](../device-api). This alleviates the burden of having to take any per device onboarding action.
+
+## Registration Flow
+
+1. An unregistered device attempts to connect to Peridio Device API for the first time ever. Typically via the [get device me](../device-api#tag/Devices/paths/~1device~1me/get) endpoint, but any endpoint will do.
+2. Peridio validates that the device's certificate is signed by a present and valid CA Certificate.
+3. Peridio registers the device creating a record of the device as well as its certificate and automatically assigning the attributes configured against the relevant CA certificate.

--- a/src/cremini/docs/reference/keys.md
+++ b/src/cremini/docs/reference/keys.md
@@ -1,0 +1,13 @@
+---
+title: Keys
+---
+
+<head>
+  <title>Ref | Keys</title>
+</head>
+
+Keys are used:
+
+  - by users to sign firmware before uploading to Peridio.
+  - by Peridio to verify uploaded firmware.
+  - by devices to verify downloaded firmware.

--- a/src/cremini/docs/reference/organizations.md
+++ b/src/cremini/docs/reference/organizations.md
@@ -9,3 +9,7 @@ title: Organizations
 An Organization is a container for your resources. You create and manage your resources in an Organization, and the Organization provides administrative capabilities for access and billing.
 
 Using multiple Organizations is a best practice for scaling your environment, as it provides a natural billing boundary for costs, isolates resources for security, gives flexibility or individuals and teams, in addition to being adaptable for new business processes.
+
+## User Access
+
+Users within an organization with a role of `admin` are able to invite other users to that organization. As part of this process the inviter will choose a role level for the invited which will dictate their access level to the organization in general.

--- a/src/cremini/docs/reference/products.md
+++ b/src/cremini/docs/reference/products.md
@@ -1,0 +1,9 @@
+---
+title: Products
+---
+
+<head>
+  <title>Ref | Products</title>
+</head>
+
+Products provide a means of logically grouping devices at the highest level within an organization. More granular grouping can be achieved via [device tags](devices#tags).

--- a/src/cremini/docs/reference/users.md
+++ b/src/cremini/docs/reference/users.md
@@ -1,0 +1,9 @@
+---
+title: Users
+---
+
+<head>
+  <title>Ref | Users</title>
+</head>
+
+A user is the logical representation of a person within Peridio.


### PR DESCRIPTION
**Why**

- We need to begin to have something in place for the cremini reference so we can gain traction iterating on it.

**How**

- Take a first pass at documenting Cremini resources in the reference.