### PR TITLE
ENG-484: add device-certificates command

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -13,7 +13,7 @@ This command installs dependencies defined in `src/package.json`.
 ## Development Server
 
 ```shell
-yarn ---cwd src start
+yarn --cwd src start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.

--- a/src/docs/cli/device-certificates/create.md
+++ b/src/docs/cli/device-certificates/create.md
@@ -1,19 +1,20 @@
 ---
-title: authenticate
+title: create
 ---
 
-# peridio devices authenticate
+# peridio device-certificates create
 
-Authenticate a device.
+Create a device certificate.
 
 ## Usage
 
 ```
 peridio \
-  devices \
-  authenticate \
+  device-certificates \
+  create \
   [OPTIONS] \
   --api-key <api-key> \
+  --device-identifier <device-identifier> \
   --certificate-path <certificate-path> \
   --organization-name <organization-name> \
   --product-name <product-name> \
@@ -36,6 +37,10 @@ Prints version information
 `--api-key <api-key>`, `$PERIDIO_API_KEY`
 
 The API key used to authenticate and authorize the request.
+
+`--device-identifier <device-identifier>`
+
+The device unique identifier.
 
 `--certificate-path <certificate-path>`
 

--- a/src/docs/cli/device-certificates/delete.md
+++ b/src/docs/cli/device-certificates/delete.md
@@ -1,22 +1,23 @@
 ---
-title: authenticate
+title: delete
 ---
 
-# peridio devices authenticate
+# peridio device-certificates delete
 
-Authenticate a device.
+Delete a device certificate.
 
 ## Usage
 
 ```
 peridio \
-  devices \
-  authenticate \
+  device-certificates \
+  delete \
   [OPTIONS] \
   --api-key <api-key> \
-  --certificate-path <certificate-path> \
+  --certificate-serial <certificate-serial> \
+  --device-identifier <device-identifier> \
   --organization-name <organization-name> \
-  --product-name <product-name> \
+  --product-name <product-name>
 ```
 
 ## Flags
@@ -37,9 +38,13 @@ Prints version information
 
 The API key used to authenticate and authorize the request.
 
-`--certificate-path <certificate-path>`
+`--certificate-serial <certificate-serial>`
 
-The certificate path.
+The device certificate serial.
+
+`--device-identifier <device-identifier>`
+
+The unique identifier of the device.
 
 `--organization-name <organization-name>`
 

--- a/src/docs/cli/device-certificates/get.md
+++ b/src/docs/cli/device-certificates/get.md
@@ -1,22 +1,23 @@
 ---
-title: authenticate
+title: get
 ---
 
-# peridio devices authenticate
+# peridio device-certificates get
 
-Authenticate a device.
+Get a device certificate.
 
 ## Usage
 
 ```
 peridio \
-  devices \
-  authenticate \
+  device-certificates \
+  get \
   [OPTIONS] \
   --api-key <api-key> \
-  --certificate-path <certificate-path> \
+  --certificate-serial <certificate-serial> \
+  --device-identifier <device-identifier> \
   --organization-name <organization-name> \
-  --product-name <product-name> \
+  --product-name <product-name>
 ```
 
 ## Flags
@@ -37,9 +38,13 @@ Prints version information
 
 The API key used to authenticate and authorize the request.
 
-`--certificate-path <certificate-path>`
+`--certificate-serial <certificate-serial>`
 
-The certificate path.
+The device certificate serial.
+
+`--device-identifier <device-identifier>`
+
+The unique identifier of the device.
 
 `--organization-name <organization-name>`
 

--- a/src/docs/cli/device-certificates/list.md
+++ b/src/docs/cli/device-certificates/list.md
@@ -1,22 +1,22 @@
 ---
-title: authenticate
+title: list
 ---
 
-# peridio devices authenticate
+# peridio device-certificates list
 
-Authenticate a device.
+List device certificates.
 
 ## Usage
 
 ```
 peridio \
-  devices \
-  authenticate \
+  device-certificates \
+  list \
   [OPTIONS] \
   --api-key <api-key> \
-  --certificate-path <certificate-path> \
+  --device-identifier <device-identifier> \
   --organization-name <organization-name> \
-  --product-name <product-name> \
+  --product-name <product-name>
 ```
 
 ## Flags
@@ -37,9 +37,9 @@ Prints version information
 
 The API key used to authenticate and authorize the request.
 
-`--certificate-path <certificate-path>`
+`--device-identifier <device-identifier>`
 
-The certificate path.
+The unique identifier of the device.
 
 `--organization-name <organization-name>`
 

--- a/src/docs/cli/products/create.md
+++ b/src/docs/cli/products/create.md
@@ -1,22 +1,22 @@
 ---
-title: authenticate
+title: create
 ---
 
-# peridio devices authenticate
+# peridio products create
 
-Authenticate a device.
+Create a product.
 
 ## Usage
 
 ```
 peridio \
-  devices \
-  authenticate \
+  products \
+  create \
   [OPTIONS] \
   --api-key <api-key> \
-  --certificate-path <certificate-path> \
-  --organization-name <organization-name> \
-  --product-name <product-name> \
+  --delta-updatable <delta-updatable> \
+  --name <name> \
+  --organization-name <organization-name>
 ```
 
 ## Flags
@@ -31,23 +31,23 @@ Prints version information
 
 ## Options
 
+`--delta-updatable <delta-updatable>`
+
+Is the product delta updatable.
+
 ### Required
 
 `--api-key <api-key>`, `$PERIDIO_API_KEY`
 
 The API key used to authenticate and authorize the request.
 
-`--certificate-path <certificate-path>`
+`--name <name>`
 
-The certificate path.
+The name of the product.
 
 `--organization-name <organization-name>`
 
 The organization to interact with.
-
-`--product-name <product-name>`
-
-The name of the product.
 
 ### Defaulted
 

--- a/src/docs/cli/products/delete.md
+++ b/src/docs/cli/products/delete.md
@@ -1,22 +1,21 @@
 ---
-title: authenticate
+title: delete
 ---
 
-# peridio devices authenticate
+# peridio products delete
 
-Authenticate a device.
+Delete a product.
 
 ## Usage
 
 ```
 peridio \
-  devices \
-  authenticate \
+  products \
+  delete \
   [OPTIONS] \
   --api-key <api-key> \
-  --certificate-path <certificate-path> \
   --organization-name <organization-name> \
-  --product-name <product-name> \
+  --product-name <product-name>
 ```
 
 ## Flags
@@ -36,10 +35,6 @@ Prints version information
 `--api-key <api-key>`, `$PERIDIO_API_KEY`
 
 The API key used to authenticate and authorize the request.
-
-`--certificate-path <certificate-path>`
-
-The certificate path.
 
 `--organization-name <organization-name>`
 

--- a/src/docs/cli/products/get.md
+++ b/src/docs/cli/products/get.md
@@ -1,22 +1,21 @@
 ---
-title: authenticate
+title: get
 ---
 
-# peridio devices authenticate
+# peridio products get
 
-Authenticate a device.
+Get a product.
 
 ## Usage
 
 ```
 peridio \
-  devices \
-  authenticate \
+  products \
+  get \
   [OPTIONS] \
   --api-key <api-key> \
-  --certificate-path <certificate-path> \
   --organization-name <organization-name> \
-  --product-name <product-name> \
+  --product-name <product-name>
 ```
 
 ## Flags
@@ -36,10 +35,6 @@ Prints version information
 `--api-key <api-key>`, `$PERIDIO_API_KEY`
 
 The API key used to authenticate and authorize the request.
-
-`--certificate-path <certificate-path>`
-
-The certificate path.
 
 `--organization-name <organization-name>`
 

--- a/src/docs/cli/products/list.md
+++ b/src/docs/cli/products/list.md
@@ -1,22 +1,20 @@
 ---
-title: authenticate
+title: list
 ---
 
-# peridio devices authenticate
+# peridio products list
 
-Authenticate a device.
+List products.
 
 ## Usage
 
 ```
 peridio \
-  devices \
-  authenticate \
+  products \
+  list \
   [OPTIONS] \
   --api-key <api-key> \
-  --certificate-path <certificate-path> \
-  --organization-name <organization-name> \
-  --product-name <product-name> \
+  --organization-name <organization-name>
 ```
 
 ## Flags
@@ -37,17 +35,9 @@ Prints version information
 
 The API key used to authenticate and authorize the request.
 
-`--certificate-path <certificate-path>`
-
-The certificate path.
-
 `--organization-name <organization-name>`
 
 The organization to interact with.
-
-`--product-name <product-name>`
-
-The name of the product.
 
 ### Defaulted
 

--- a/src/docs/cli/products/update.md
+++ b/src/docs/cli/products/update.md
@@ -1,20 +1,21 @@
 ---
-title: authenticate
+title: update
 ---
 
-# peridio devices authenticate
+# peridio products update
 
-Authenticate a device.
+update a product.
 
 ## Usage
 
 ```
 peridio \
-  devices \
-  authenticate \
+  products \
+  update \
   [OPTIONS] \
   --api-key <api-key> \
-  --certificate-path <certificate-path> \
+  --delta-updatable <delta-updatable> \
+  --name <name> \
   --organization-name <organization-name> \
   --product-name <product-name> \
 ```
@@ -31,15 +32,19 @@ Prints version information
 
 ## Options
 
+`--delta-updatable <delta-updatable>`
+
+Is the product delta updatable.
+
+`--name <name>`
+
+The name of the product.
+
 ### Required
 
 `--api-key <api-key>`, `$PERIDIO_API_KEY`
 
 The API key used to authenticate and authorize the request.
-
-`--certificate-path <certificate-path>`
-
-The certificate path.
 
 `--organization-name <organization-name>`
 

--- a/src/sidebars.js
+++ b/src/sidebars.js
@@ -36,12 +36,35 @@ const sidebars = {
         {
           collapsible: false,
           type: 'category',
+          label: 'device certificates',
+          items: [
+            'cli/device-certificates/create',
+            'cli/device-certificates/delete',
+            'cli/device-certificates/get',
+            'cli/device-certificates/list',
+          ],
+        },
+        {
+          collapsible: false,
+          type: 'category',
           label: 'firmwares',
           items: [
             'cli/firmwares/create',
             'cli/firmwares/delete',
             'cli/firmwares/get',
             'cli/firmwares/list',
+          ],
+        },
+        {
+          collapsible: false,
+          type: 'category',
+          label: 'products',
+          items: [
+            'cli/products/create',
+            'cli/products/delete',
+            'cli/products/get',
+            'cli/products/list',
+            'cli/products/update',
           ],
         },
         {


### PR DESCRIPTION
Related: ENG-471

Why:

We want to add `device-certificates` and `products` command documentation

How:

- add device-certificates command
- add products command