### PR TITLE
ENG-516: move delta updates to deployments

### DIFF
--- a/src/docs/cli/deployments/create.md
+++ b/src/docs/cli/deployments/create.md
@@ -14,6 +14,10 @@ Prints help information.
 
 ## Options
 
+`--delta-updatable <delta-updatable>`
+
+Is the deployment delta updatable.
+
 `--version <version>`
 
 The version of the deployment. Must respect this format: https://hexdocs.pm/elixir/Version.html#module-requirements

--- a/src/docs/cli/deployments/update.md
+++ b/src/docs/cli/deployments/update.md
@@ -14,6 +14,10 @@ Prints help information.
 
 ## Options
 
+`--delta-updatable <delta-updatable>`
+
+Is the deployment delta updatable.
+
 `--tags <tags>`
 
 The device tags list.

--- a/src/docs/cli/products/create.md
+++ b/src/docs/cli/products/create.md
@@ -14,10 +14,6 @@ Prints help information.
 
 ## Options
 
-`--delta-updatable <delta-updatable>`
-
-Is the product delta updatable.
-
 ### Required
 
 `--name <name>`

--- a/src/docs/cli/products/update.md
+++ b/src/docs/cli/products/update.md
@@ -14,10 +14,6 @@ Prints help information.
 
 ## Options
 
-`--delta-updatable <delta-updatable>`
-
-Is the product delta updatable.
-
 `--name <name>`
 
 The name of the product.

--- a/src/openapi/peridio-admin-openapi.yaml
+++ b/src/openapi/peridio-admin-openapi.yaml
@@ -311,9 +311,6 @@ paths:
           application/json:
             schema:
               properties:
-                delta_updatable:
-                  $ref: "#/components/schemas/delta-updatable"
-                  default: false
                 name:
                   $ref: "#/components/schemas/product-name"
               required:
@@ -394,8 +391,6 @@ paths:
                 product:
                   type: object
                   properties:
-                    delta_updatable:
-                      $ref: "#/components/schemas/delta-updatable"
                     name:
                       $ref: "#/components/schemas/product-name"
               required:
@@ -457,6 +452,9 @@ paths:
               properties:
                 conditions:
                   $ref: "#/components/schemas/deployment-conditions"
+                delta_updatable:
+                  $ref: "#/components/schemas/delta-updatable"
+                  default: false
                 firmware:
                   $ref: "#/components/schemas/firmware-uuid"
                 is_active:
@@ -564,6 +562,8 @@ paths:
                       $ref: "#/components/schemas/deployment-name"
                     conditions:
                       $ref: "#/components/schemas/deployment-conditions"
+                    delta_updatable:
+                      $ref: "#/components/schemas/delta-updatable"
                     firmware:
                       $ref: "#/components/schemas/firmware-uuid"
                     is_active:
@@ -1551,6 +1551,8 @@ components:
       properties:
         conditions:
           $ref: "#/components/schemas/deployment-conditions"
+        delta_updatable:
+          $ref: "#/components/schemas/delta-updatable"
         firmware_uuid:
           $ref: "#/components/schemas/firmware-uuid"
         is_active:
@@ -1728,8 +1730,6 @@ components:
     product:
       type: object
       properties:
-        delta_updatable:
-          $ref: "#/components/schemas/delta-updatable"
         name:
           $ref: "#/components/schemas/product-name"
     product-architecture:


### PR DESCRIPTION
Why:

We want to move delta updates from products to deployments and update our documentation accordingly.