### PR TITLE
ENG-544: add ca certificate guide

### DIFF
--- a/src/docs/guides/creating-ca-certificates.md
+++ b/src/docs/guides/creating-ca-certificates.md
@@ -1,0 +1,62 @@
+# Creating CA Certificates
+
+This guide describes how to create CA certificates.
+
+To learn more about Peridio CA certificates in general, see the [CA certificates](/reference/ca-certificates) reference.
+
+## Prerequisites
+
+- [Peridio CLI](https://github.com/peridio/morel/releases).
+  - Last tested with version 0.3.0.
+
+## Obtain a CA Certificate File
+
+There are many ways to obtain a CA certificate file including but not limited to generating your own or purchasing one from a company that specializes in certificate management. For the sake of example you may see the [creating X.509 certificates with OpenSSL](creating-x509-certificates-with-openssl) guide. If you follow that guide, use an intermediate certificate as your CA certificate for the purpose of this guide.
+
+## Obtain a Verification Certificate File
+
+In order to verify that you control the private key associated with the CA certificate you wish to upload, Peridio requires you upload a verification certificate. This is an end entity certificate signed by the private key associated with the CA certificate you wish to upload and whose common name is a verification code provided by Peridio.
+
+### Obtain a Verification Code
+
+You will use the obtained verification code as the common name of the verification certificate.
+
+**Peridio CLI**
+
+```console
+peridio ca-certificates create-verification-code
+```
+
+:warning: This code is consumed upon creating a CA certificate and expires after one week.
+
+**Peridio Web Console**
+
+1. Navigate to your organization in the [Peridio Web Console](https://console.cremini.peridio.com).
+2. Navigate to the "Certificates" page.
+3. Navigate to the "New Certificate Authority" page by clicking "Add Certificate Authority".
+4. The verification code will be displayed on the page.
+
+:warning: This code is different everytime you open or refresh the page to upload a CA certificate. The common name of the verification certificate you upload must match the code displayed on the page.
+
+### Create a Verification Certificate File
+
+See the [creating X.509 certificates with OpenSSL](creating-x509-certificates-with-openssl) guide and create an end entity certificate whose common name is the verification code you obtained earlier.
+
+## Submit the CA Certificate and Verification Certificate to Peridio
+
+**Peridio CLI**
+
+```
+peridio ca-certificates create \
+  --certificate-path ca-certificate.pem \
+  --verification-certificate-path verification-certificate.pem
+```
+
+:warning: The common name of the verification certificate you upload must match a verification code created via the Peridio CLI or the Peridio Admin API.
+
+**Peridio Web Console**
+
+1. You should still be on the "New Certificate Authority" page from when you obtained a verification code.
+2. Input the CA certificate and verification certificate into the respective file inputs and submit the form.
+
+:warning: The common name of the verification certificate you upload must match the code displayed on the page.

--- a/src/docs/guides/creating-deployments.md
+++ b/src/docs/guides/creating-deployments.md
@@ -6,7 +6,7 @@ To learn more about Peridio deployments in general, see the [deployments](/refer
 
 ## Prerequisites
 
-- [peridio](https://github.com/peridio/morel/releases)
+- [Peridio CLI](https://github.com/peridio/morel/releases).
   - Last tested with version 0.3.0.
 
 In order to create a deployment it must be associated with a preexisting product and firmware. To learn how to create a product, see the [creating products](/guides/creating-products) guide. To learn how to create firmware, see the [creating firmware](/guides/creating-firmware) guide.

--- a/src/docs/guides/creating-firmware-signing-keys.md
+++ b/src/docs/guides/creating-firmware-signing-keys.md
@@ -6,9 +6,9 @@ To learn more about Peridio firmware signing keys in general, see the [firmware 
 
 ## Prerequisites
 
-- [fwup](https://github.com/fwup-home/fwup)
+- [fwup CLI](https://github.com/fwup-home/fwup).
   - Last tested with version 1.9.1.
-- [peridio](https://github.com/peridio/morel/releases)
+- [Peridio CLI](https://github.com/peridio/morel/releases).
   - Last tested with version 0.3.0.
 
 ## Creation

--- a/src/docs/guides/creating-firmware.md
+++ b/src/docs/guides/creating-firmware.md
@@ -6,9 +6,9 @@ To learn more about Peridio firmware in general, see the [firmwares](/reference/
 
 ## Prerequisites
 
-- [fwup](https://github.com/fwup-home/fwup)
+- [fwup CLI](https://github.com/fwup-home/fwup).
   - Last tested with version 1.9.1.
-- [peridio](https://github.com/peridio/morel/releases)
+- [Peridio CLI](https://github.com/peridio/morel/releases).
   - Last tested with version 0.3.0.
 
 In order to create a firmware it must be associated with a preexisting product. To learn how to create a product, see the [creating products](/guides/creating-products) guide.

--- a/src/docs/guides/creating-products.md
+++ b/src/docs/guides/creating-products.md
@@ -6,7 +6,7 @@ To learn more about Peridio products in general, see the [products](/reference/p
 
 ## Prerequisites
 
-- [peridio](https://github.com/peridio/morel/releases)
+- [Peridio CLI](https://github.com/peridio/morel/releases).
   - Last tested with version 0.3.0.
 
 ## Create Product

--- a/src/docs/guides/creating-x509-certificates-with-openssl.md
+++ b/src/docs/guides/creating-x509-certificates-with-openssl.md
@@ -4,7 +4,7 @@ This guide describes how to create X.509 certificates with [OpenSSL](https://www
 
 ## Prerequisites
 
-- [OpenSSL](https://www.openssl.org/)
+- [OpenSSL CLI](https://www.openssl.org/).
   - Last tested with version 3.0.4 21 Jun 2022.
 
 ## Hardware Constraints

--- a/src/docs/reference/firmwares.md
+++ b/src/docs/reference/firmwares.md
@@ -4,7 +4,7 @@ title: Firmwares
 
 Firmwares are the data you wish to distribute to devices.
 
-Peridio requires the use of [fwup](https://github.com/fwup-home/fwup) archives as the packaing format for firmwares. This means the binaries you upload to Peridio and the binaries your devices will download from Peridio are fwup archives. The contents of an archive are up to you; ranging from no files, to 1 file, to `n` files. They are capable of packaging an arbitrary stringy metadata payload. Note that fwup archives themselves are ZIP archives and can be interacted with as such.
+Peridio requires the use of [fwup](https://github.com/fwup-home/fwup) archives as the packaging format for firmwares. This means the binaries you upload to Peridio and the binaries your devices will download from Peridio are fwup archives. The contents of an archive are up to you; ranging from no files, to 1 file, to `n` files. They are capable of packaging an arbitrary stringy metadata payload. Note that fwup archives themselves are ZIP archives and can be interacted with as such.
 
 To learn more about how to use firmware, see the [creating firmware](/guides/creating-firmware) guide.
 

--- a/src/sidebars.js
+++ b/src/sidebars.js
@@ -146,6 +146,7 @@ const sidebars = {
       type: 'category',
       label: 'Guides',
       items: [
+        'guides/creating-ca-certificates',
         'guides/creating-deployments',
         'guides/creating-firmware',
         'guides/creating-firmware-signing-keys',


### PR DESCRIPTION
**Why**

- Allow the Peridio web console to not get bogged down by excessive inline documentation.

**How**

- Write the guide.
- Update standard for how we write prerequisites.
- Fix typo in firmware reference.