### PR TITLE
ENG-566: update binaries api

### DIFF
--- a/src/openapi/peridio-admin-openapi.yaml
+++ b/src/openapi/peridio-admin-openapi.yaml
@@ -4,6 +4,19 @@ info:
   title: Peridio Admin API
   version: "v1"
   description: |
+    # Expanding Responses
+
+    Some endpoints are able to return more data than they normally do by expanding their response.
+    When this is possible the endpoint will specify the `expand` field and will document which
+    fields can be expanded. The `expand` field takes an array of string field names that identify
+    which fields you wish to expand.
+
+    For example:
+
+    ```text
+    /foo?expand[]=bar&expand[]=baz
+    ```
+
     # Search Query Language
 
     Some endpoints specify a `search` parameter. The value of this parameter must be a string that
@@ -87,24 +100,38 @@ servers:
   - url: https://api.cremini.peridio.com
 security:
   - api_key: []
+tags:
+  - name: Experimental Overview
+    x-displayName: Overview
+    description: |
+      Experimental endpoints are documented here, but access to them is only available through a
+      private, closed beta group.
+
+      All experimental endpoints are subject to change and their promotion to general availability
+      in the Peridio Admin API is not guaranteed.
 x-tagGroups:
-  - name: "Endpoints"
+  - name: Endpoints
     tags:
-      - "Artifacts"
-      - "Artifact Versions"
-      - "CA Certificates"
-      - "Deployments"
-      - "Device Certificates"
-      - "Devices"
-      - "Firmwares"
-      - "Keys"
-      - "Organization Users"
-      - "Product Users"
-      - "Products"
-      - "Users"
+      - CA Certificates
+      - Deployments
+      - Device Certificates
+      - Devices
+      - Firmwares
+      - Keys
+      - Organization Users
+      - Product Users
+      - Products
+      - Users
+  - name: Experimental
+    tags:
+      - Experimental Overview
+      - Artifacts
+      - Artifact Versions
+      - Binaries
 paths:
   /artifacts:
     post:
+      operationId: create-artifact
       summary: create Artifact
       tags:
         - "Artifacts"
@@ -133,6 +160,7 @@ paths:
                   artifact:
                     $ref: "#/components/schemas/artifact"
     get:
+      operationId: list-artifacts
       summary: list Artifacts
       tags:
         - "Artifacts"
@@ -178,7 +206,8 @@ paths:
                     $ref: "#/components/schemas/array-of-artifacts"
   /artifacts/{artifact_id}:
     get:
-      summary: get Artifact
+      operationId: retrieve-artifact
+      summary: retrieve Artifact
       tags:
         - "Artifacts"
       parameters:
@@ -197,6 +226,7 @@ paths:
                   artifact:
                     $ref: "#/components/schemas/artifact"
     patch:
+      operationId: update-artifact
       summary: update Artifact
       tags:
         - "Artifacts"
@@ -227,6 +257,7 @@ paths:
                     $ref: "#/components/schemas/artifact"
   /artifact-versions:
     post:
+      operationId: create-artifact-version
       summary: create Artifact Version
       tags:
         - "Artifact Versions"
@@ -258,6 +289,7 @@ paths:
                   artifact_version:
                     $ref: "#/components/schemas/artifact-version"
     get:
+      operationId: list-artifact-versions
       summary: list Artifact Versions
       tags:
         - "Artifact Versions"
@@ -305,7 +337,8 @@ paths:
                     $ref: "#/components/schemas/array-of-artifact-versions"
   /artifact-versions/{artifact_version_id}:
     get:
-      summary: get Artifact Version
+      operationId: retrieve-artifact-version
+      summary: retrieve Artifact Version
       tags:
         - "Artifact Versions"
       parameters:
@@ -324,6 +357,7 @@ paths:
                   artifact_version:
                     $ref: "#/components/schemas/artifact-version"
     patch:
+      operationId: update-artifact-version
       summary: update Artifact Version
       tags:
         - "Artifact Versions"
@@ -352,7 +386,13 @@ paths:
                     $ref: "#/components/schemas/artifact-version"
   /binaries:
     post:
+      operationId: create-binary
       summary: create Binary
+      description: |
+        Create the initial record of the binary.
+
+        To upload the actual binary, use [upload Binary](#tag/Binaries/operation/upload-binary).
+        To finalize the binary for use, use [sign Binary](#tag/Binaries/operation/sign-binary).
       tags:
         - "Binaries"
       requestBody:
@@ -368,7 +408,7 @@ paths:
                 organization_name:
                   $ref: "#/components/schemas/organization-name"
                 target:
-                  $ref: "#/components/schemas/binary-target"
+                  $ref: "#/components/schemas/target-triplet"
               required:
                 - artifact_version_id
                 - organization_name
@@ -383,6 +423,7 @@ paths:
                   binary:
                     $ref: "#/components/schemas/binary"
     get:
+      operationId: list-binaries
       summary: list Binaries
       tags:
         - "Binaries"
@@ -407,7 +448,7 @@ paths:
         - name: search
           in: query
           description: |
-            A search query per the [search query language](#section/Search-Query-Language).
+            See [search query language](#section/Search-Query-Language).
 
             |Key|Operators|Value|
             |-|-|-|
@@ -430,7 +471,8 @@ paths:
                     $ref: "#/components/schemas/array-of-binaries"
   /binaries/{binary_id}:
     get:
-      summary: get Binary
+      operationId: retrieve-binary
+      summary: retrieve Binary
       tags:
         - "Binaries"
       parameters:
@@ -439,6 +481,19 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/binary-id"
+        - name: expand
+          description: |
+            See [expanding responses](#section/Expanding-Responses).
+
+            |Field|Description|
+            |-|-|
+            |`url`|Includes a presigned URL for downloading the binary.|
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         "200":
           description: Ok.
@@ -449,6 +504,7 @@ paths:
                   binary:
                     $ref: "#/components/schemas/binary"
     patch:
+      operationId: update-binary
       summary: update Binary
       tags:
         - "Binaries"
@@ -468,6 +524,123 @@ paths:
                   $ref: "#/components/schemas/binary-description"
       responses:
         "200":
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                properties:
+                  binary:
+                    $ref: "#/components/schemas/binary"
+  /binaries/{binary_id}/abort-upload:
+    post:
+      operationId: abort-upload-binary
+      summary: abort upload Binary
+      description: |
+        Aborts the current upload of a binary.
+
+        To create the initial record of the binary, use
+        [create Binary](#tag/Binaries/operation/create-binary).
+        To upload the actual binary, use [upload Binary](#tag/Binaries/operation/upload-binary).
+        To finalize the binary for use, use [sign Binary](#tag/Binaries/operation/sign-binary).
+
+        The request will fail if:
+
+        - The value of `upload_status` for the specified binary is not `in_progress` prior to this
+          request.
+
+        If successful, the specified binary will be altered in the following manner:
+
+        - `upload_status` will be updated to `aborted`. Any bytes Peridio may have received up
+          till this point will be discarded. You may attempt to upload the binary again.
+      tags:
+        - "Binaries"
+      responses:
+        "204":
+          description: Ok.
+  /binaries/{binary_id}/upload:
+    post:
+      operationId: upload-binary
+      summary: upload Binary
+      description: |
+        Upload the actual binary.
+
+        To create the initial record of the binary, use
+        [create Binary](#tag/Binaries/operation/create-binary).
+        To abort the binary upload, use
+        [abort upload Binary](#tag/Binaries/operation/abort-upload-binary).
+        To finalize the binary for use, use [sign Binary](#tag/Binaries/operation/sign-binary).
+
+        The request will fail if:
+
+        - The value of `upload_status` for the specified binary is not one of: `not_started`,
+          `in_progress`, or `aborted` prior to this request.
+      tags:
+        - "Binaries"
+      parameters:
+        - name: Content-Range
+          description: |
+            Standard HTTP Content-Range header. Indicates what portion of the binary you are
+            uploading. Acceptable values take the form `bytes <range-start>-<range-end>/<size>`.
+            This API will return an error if supplied `*` for any of the above placeholders.
+
+            While this header is typically not required, it is conditionally required when a
+            portion of the binary has already been uploaded to Peridio. In that case you must
+            supply this header, and the `<range-start>` must match the `size` reported by
+            performing a [retrieve Binary](#tag/Binaries/operation/retrieve-binary) request.
+
+            See the [uploading binaries guide](/guides/uploading-binaries#resuming-uploads).
+          in: header
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "204":
+          description: Ok.
+  /binaries/{binary_id}/sign:
+    post:
+      operationId: sign-binary
+      summary: sign Binary
+      tags:
+        - "Binaries"
+      description: |
+        Finalize the binary for use.
+
+        To create the initial record of the binary, use
+        [create Binary](#tag/Binaries/operation/create-binary).
+        To upload the actual binary, use [upload Binary](#tag/Binaries/operation/upload-binary).
+
+        The request will fail if:
+
+        - The `signature` is invalid for the key identified by the `signing_key_id`.
+        - The value of `upload_status` for the specified binary is not `in_progress` prior to this
+          request.
+
+        If successful, the specified binary will be altered in the following manner:
+
+        - `signing_key_id` and `signature` will be updated to the values provided.
+        - `upload_status` will be updated to `complete`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                signing_key_id:
+                  $ref: "#/components/schemas/key-key"
+                signature:
+                  $ref: "#/components/schemas/signature"
+              required:
+                - signing_key_id
+                - signature
+      responses:
+        "201":
           description: Ok.
           content:
             application/json:
@@ -1486,6 +1659,19 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/firmware-uuid"
+        - name: expand
+          description: |
+            See [expanding responses](#section/Expanding-Responses).
+
+            |Field|Description|
+            |-|-|
+            |`url`|Includes a presigned URL for downloading the firmware.|
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         "200":
           description: Ok.
@@ -2037,6 +2223,11 @@ components:
       properties:
         artifact_version_id:
           $ref: "#/components/schemas/artifact-version-id"
+        signing_key_id:
+          oneOf:
+            - type: "null"
+            - type: string
+              format: uuid
         description:
           oneOf:
             - $ref: "#/components/schemas/binary-description"
@@ -2046,11 +2237,29 @@ components:
         inserted_at:
           type: string
           format: date-time
+        signature:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/signature"
         target:
-          $ref: "#/components/schemas/binary-target"
+          $ref: "#/components/schemas/target-triplet"
         updated_at:
           type: string
           format: date-time
+        upload_status:
+          type: string
+          enum:
+            - not_started
+            - in_progress
+            - aborted
+            - complete
+        size:
+          description: |
+            How many bytes have been uploaded for the binary. The value is subject to change until
+            `upload_status` is `complete`.
+          type: integer
+          minimum: 0
+          maximum: 10_000_000_000
     binary-description:
       type: string
       minLength: 1
@@ -2058,10 +2267,12 @@ components:
     binary-id:
       type: string
       format: uuid
-    binary-target:
+    target-triplet:
       type: string
       minLength: 1
       maxLength: 128
+      description: A target triplet string that restricts which devices are compatible with this binary.
+      example: arm-linux-androideabi
     ca-certificate:
       type: object
       properties:
@@ -2330,6 +2541,11 @@ components:
     serial:
       type: string
       example: "522154175989108335861639249273408275957749326848"
+    signature:
+      type: string
+      description: |
+        An ed25519 signature  of the SHA256 hash of the binary represented as a 64-byte hex
+        encoded string.
     user-me:
       allOf:
         - type: object


### PR DESCRIPTION
- Add generic documentation for expanding responses.
- Create experimental section of endpoints and move release orchestration endpoints into it.
- Add operation IDs to all release orchestration endpoints to cleanup their linkable URLs.
- Improve documentation for create, upload, and sign binaries to indicate they are linked and how.
- Document expandable URL field on retrieve Binary.
- Document expandable URL field on get Firmware.
- Add abort Binary upload.
- Add upload Binary.
- Add sign Binary.
- Add size, upload_status, signature, and signing key ID to binary schema.