### PR TITLE
ENG-573: docs, cli, rust sdk: add bundles

### DIFF
--- a/src/docs/cli/artifact-versions/create.md
+++ b/src/docs/cli/artifact-versions/create.md
@@ -20,7 +20,7 @@ The description of the artifact version.
 
 ### Required
 
-`--artifact_prn <artifact_prn>`
+`--artifact-prn <artifact-prn>`
 
 The Peridio Resource Name (PRN) of the artifact.
 

--- a/src/docs/cli/artifact-versions/get.md
+++ b/src/docs/cli/artifact-versions/get.md
@@ -1,8 +1,8 @@
 ---
-title: retreive
+title: get
 ---
 
-# peridio artifact-versions retrieve
+# peridio artifact-versions get
 
 Retrieve an artifact version.
 
@@ -14,6 +14,6 @@ Prints help information.
 
 ### Required
 
-`--artifact_version_prn <artifact_version_prn>`
+`--prn <prn>`
 
 The Peridio Resource Name (PRN) of the artifact version.

--- a/src/docs/cli/artifact-versions/update.md
+++ b/src/docs/cli/artifact-versions/update.md
@@ -20,6 +20,6 @@ The artifact version description.
 
 ### Required
 
-`--artifact_version_prn <artifact_version_prn>`
+`--prn <prn>`
 
 The Peridio Resource Name (PRN) of the artifact version.

--- a/src/docs/cli/artifacts/create.md
+++ b/src/docs/cli/artifacts/create.md
@@ -24,6 +24,6 @@ The artifact description.
 
 The name of the artifact.
 
-`--organization_prn <organization_prn>`
+`--organization-prn <organization-prn>`
 
 The Peridio Resource Name (PRN) of the organization.

--- a/src/docs/cli/artifacts/get.md
+++ b/src/docs/cli/artifacts/get.md
@@ -1,8 +1,8 @@
 ---
-title: retreive
+title: get
 ---
 
-# peridio artifacts retrieve
+# peridio artifacts get
 
 Retrieve an artifact.
 
@@ -14,6 +14,6 @@ Prints help information.
 
 ### Required
 
-`--artifact_prn <artifact_prn>`
+`--prn <prn>`
 
 The Peridio Resource Name (PRN) of the artifact.

--- a/src/docs/cli/artifacts/update.md
+++ b/src/docs/cli/artifacts/update.md
@@ -24,6 +24,6 @@ The name of the artifact.
 
 ### Required
 
-`--artifact_prn <artifact_prn>`
+`--prn <prn>`
 
 The Peridio Resource Name (PRN) of the artifact.

--- a/src/docs/cli/bundles/create.md
+++ b/src/docs/cli/bundles/create.md
@@ -1,0 +1,31 @@
+---
+title: create
+---
+
+# peridio bundles create
+
+Create a bundle.
+
+## Flags
+
+`-h`, `--help`
+
+Prints help information.
+
+## Options
+
+`--artifact-version-prns <artifact-version-prns>`
+
+The Peridio Resource Name (PRN) of a single artifact version that will be contained in the bundle. Multiple artifact versions are supported using the format:
+
+```
+--artifact-version-prns prn1 \
+--artifact-version-prns prn2 \
+--artifact-version-prns prn3
+```
+
+### Required
+
+`--organization-prn <organization-prn>`
+
+The Peridio Resource Name (PRN) of the organization.

--- a/src/docs/cli/bundles/get.md
+++ b/src/docs/cli/bundles/get.md
@@ -1,0 +1,19 @@
+---
+title: get
+---
+
+# peridio bundles get
+
+Retrieve a bundle.
+
+## Flags
+
+`-h`, `--help`
+
+Prints help information.
+
+### Required
+
+`--prn <prn>`
+
+The Peridio Resource Name (PRN) of the bundle.

--- a/src/docs/cli/bundles/list.md
+++ b/src/docs/cli/bundles/list.md
@@ -1,0 +1,33 @@
+---
+title: list
+---
+
+# peridio bundles list
+
+List bundles information.
+
+## Flags
+
+`-h`, `--help`
+
+Prints help information.
+
+## Options
+
+`--limit <limit>`
+
+Specifies the max length of the returned results.
+
+`--order <order>`
+
+Controls whether the order of results is ascending or descending.
+
+`--page <page>`
+
+A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the `next_page` value returned in a previous response to request subsequent results.
+
+### Required
+
+`--search <search>`
+
+A search query per the [search query language](https://docs.peridio.com/admin-api#section/Search-Query-Language). The search query must include the organization prn.

--- a/src/docs/cli/cohorts/create.md
+++ b/src/docs/cli/cohorts/create.md
@@ -24,10 +24,10 @@ The cohort description.
 
 The name of the cohort.
 
-`--organization_prn <organization_prn>`
+`--organization-prn <organization-prn>`
 
 The Peridio Resource Name (PRN) of the organization.
 
-`--product_prn <organization_prn>`
+`--product-prn <product-prn>`
 
 The Peridio Resource Name (PRN) of the product.

--- a/src/docs/cli/cohorts/get.md
+++ b/src/docs/cli/cohorts/get.md
@@ -1,8 +1,8 @@
 ---
-title: retreive
+title: get
 ---
 
-# peridio cohorts retrieve
+# peridio cohorts get
 
 Retrieve an cohort.
 
@@ -14,6 +14,6 @@ Prints help information.
 
 ### Required
 
-`--cohort_prn <cohort_prn>`
+`--prn <prn>`
 
 The Peridio Resource Name (PRN) of the cohort.

--- a/src/docs/cli/cohorts/update.md
+++ b/src/docs/cli/cohorts/update.md
@@ -24,6 +24,6 @@ The name of the cohort.
 
 ### Required
 
-`--cohort_prn <cohort_prn>`
+`--prn <prn>`
 
 The Peridio Resource Name (PRN) of the cohort.

--- a/src/sidebars.js
+++ b/src/sidebars.js
@@ -16,7 +16,7 @@ const sidebars = {
           items: [
             'cli/artifacts/create',
             'cli/artifacts/list',
-            'cli/artifacts/retrieve',
+            'cli/artifacts/get',
             'cli/artifacts/update',
           ],
         },
@@ -26,9 +26,14 @@ const sidebars = {
           items: [
             'cli/artifact-versions/create',
             'cli/artifact-versions/list',
-            'cli/artifact-versions/retrieve',
+            'cli/artifact-versions/get',
             'cli/artifact-versions/update',
           ],
+        },
+        {
+          type: 'category',
+          label: 'bundles',
+          items: ['cli/bundles/create', 'cli/bundles/list', 'cli/bundles/get'],
         },
         {
           type: 'category',
@@ -48,7 +53,7 @@ const sidebars = {
           items: [
             'cli/cohorts/create',
             'cli/cohorts/list',
-            'cli/cohorts/retrieve',
+            'cli/cohorts/get',
             'cli/cohorts/update',
           ],
         },


### PR DESCRIPTION
This PR:

- Adds documentation for `bundles` in the CLI.
- Shows the correct way of using CLI options for several entities by replacing underscores for scores. e.g. `--artifact_prn <artifact_prn>` `--artifact-prn <artifact-prn>`.
- Renames the documentation page for fetching a single resource in the CLI from `retrieve` to `get`.